### PR TITLE
Change calculation of ftime to use value provided by the frame object

### DIFF
--- a/modeling/data_ingestion.py
+++ b/modeling/data_ingestion.py
@@ -145,7 +145,7 @@ class FeatureExtractor:
             #     print(f'processing frame {fcount}')
             if cur_target_frame == len(frame_list):
                 break
-            ftime = int((fcount / fps) * 1000)
+            ftime = int(frame.time * 1000) 
             if ftime == frame_list[cur_target_frame].curr_time:
                 frame_list[cur_target_frame].image = frame.to_image()
                 yield frame_list[cur_target_frame]


### PR DESCRIPTION
Frame timestamp was being calculated by dividing the frame number by the average frames per second.  That is less reliable than using the timestamp provided by the frame object in the decoded video stream.