### PR TITLE
Removing a fatal error in 2.0

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,7 +64,8 @@ class SwtDetection(ClamsApp):
         predictions = self.classifier.process_video(vd.location)
         timeframes = self.stitcher.create_timeframes(predictions)
 
-        new_view.new_contain(AnnotationTypes.TimeFrame, document=vd.id)
+        new_view.new_contain(
+            AnnotationTypes.TimeFrame, document=vd.id, timeUnit='milliseconds')
         for tf in timeframes:
             timeframe_annotation = new_view.new_annotation(AnnotationTypes.TimeFrame)
             timeframe_annotation.add_property("start", tf.start)

--- a/metadata.py
+++ b/metadata.py
@@ -28,7 +28,7 @@ def appmetadata() -> AppMetadata:
     )
 
     metadata.add_input(DocumentTypes.VideoDocument, required=True)
-    metadata.add_output(AnnotationTypes.TimeFrame)
+    metadata.add_output(AnnotationTypes.TimeFrame, timeUnit='milliseconds')
     
     # TODO: defaults are the same as in modeling/config/classifier.yml, which is possibly
     # not a great idea, should perhaps read defaults from the configuration file. There is

--- a/modeling/classify.py
+++ b/modeling/classify.py
@@ -76,7 +76,7 @@ class Classifier:
         logging.info(f'processing {mp4_file}...')
         predictions = []
         vidcap = cv2.VideoCapture(mp4_file)
-        if vidcap.isOpened():
+        if not vidcap.isOpened():
             raise IOError(f'Could not open {mp4_file}')
         fps = round(vidcap.get(cv2.CAP_PROP_FPS), 2)
         fc = vidcap.get(cv2.CAP_PROP_FRAME_COUNT)


### PR DESCRIPTION
### Overview

Version 2.0 had a nasty error which was not caught when it was tested.

### Changes

- Fixed for good the cv2 error when failing to open video file (#49)
- Added timeUnit specification to view metadata