### PR TITLE
Releasing 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,12 +255,13 @@ $RECYCLE.BIN/
 # MacOS FInder information
 .DS_Store
 
-# Files created by data_ingestion
+# Files created by data_ingestion or visualization
 modeling/features
 modeling/results*/*kfold*pt
 modeling/results*/*kfold*csv
 modeling/results*/*kfold*txt
 modeling/vectorized/*
+modeling/html
 
 # Files used or created by classify.py
 modeling/data/*

--- a/Containerfile
+++ b/Containerfile
@@ -24,8 +24,8 @@ ENV CLAMS_APP_VERSION ${CLAMS_APP_VERSION}
 
 WORKDIR /app
 
-COPY requirements-app.txt .
-RUN pip install --no-cache-dir -r /app/requirements-app.txt
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r /app/requirements.txt
 
 COPY . .
 RUN python /app/dl_backbone.py

--- a/README.md
+++ b/README.md
@@ -40,61 +40,42 @@ Using the app to process a MMIF file:
 curl -X POST -d@example-mmif.json http://localhost:5000/
 ```
 
-This may take a while depending on the size of the video file embedded in the MMIF file. It should return a MMIF object with timeframes added, for example
+This may take a while depending on the size of the video file embedded in the MMIF file. It should return a MMIF object with TimeFrame and TimePoint annotations added.
+
+
+### Output details
+
+A TimeFrame looks as follows (the scores are somewhat condensed for clarity):
 
 ```json
 {
-  "metadata": {
-    "mmif": "http://mmif.clams.ai/0.4.0"
-  },
-  "documents": [
-    {
-      "@type": "http://mmif.clams.ai/0.4.0/vocabulary/VideoDocument",
-      "properties": {
-        "mime": "video/mpeg",
-        "id": "m1",
-        "location": "file:///data/video/cpb-aacip-690722078b2-shrunk.mp4"
-      }
-    }
-  ],
-  "views": [
-    {
-      "id": "v_0",
-      "metadata": {
-        "timestamp": "2023-11-06T20:00:18.311889",
-        "app": "http://apps.clams.ai/swt-detection",
-        "contains": {
-          "http://mmif.clams.ai/vocabulary/TimeFrame/v1": {
-            "document": "m1"
-          }
-        },
-        "parameters": {
-          "pretty": "True"
-        }
-      },
-      "annotations": [
-        {
-          "@type": "http://mmif.clams.ai/vocabulary/TimeFrame/v1",
-          "properties": {
-            "start": 30000,
-            "end": 40000,
-            "frameType": "slate",
-            "score": 3.909090909090909,
-            "id": "tf_1"
-          }
-        },
-        {
-          "@type": "http://mmif.clams.ai/vocabulary/TimeFrame/v1",
-          "properties": {
-            "start": 56000,
-            "end": 58000,
-            "frameType": "slate",
-            "score": 1.3333333333333333,
-            "id": "tf_2"
-          }
-        }
-      ]
-    }
-  ]
+  "@type": "http://mmif.clams.ai/vocabulary/TimeFrame/v1",
+  "properties": {
+    "frameType": "bars",
+    "score": 0.9999,
+    "scores": [0.9998, 0.9999, 0.9998, 0.9999, 0.9999],
+    "targets": ["tp_1", "tp_2", "tp_3", "tp_4", "tp_5"],
+    "representatives": ["tp_2"],
+    "id": "tf_1"
+  }
 }
 ```
+
+The `targets` property containes the identifiers of the TimePoints that are included in the TimeFrame, in `scores` we have the TimePoint scores for the "bars" frame type, in `score` we have the average score for the entire TimeFrame, and in `representatives` we have pointers to TimePoints that are considered representative for thie TimeFrame.
+
+Only TimePoints that are included in a TimeFrame will be in the MMIF output, here is one (heavily condensed for clarity and only showing four of the labels):
+
+```json
+{
+  "@type": "http://mmif.clams.ai/vocabulary/TimePoint/v1",
+  "properties": {
+    "timePont": 0,
+    "label": "B",
+    "labels": ["B", "S", "S:H", "S:C"],
+    "scores": [0.9998, 5.7532e-08, 2.4712e-13, 1.9209e-12],
+    "id": "tp_1"
+  }
+}
+```
+
+The `label` property has the raw label for the TimePoint (which is potentially different from the frameType in the TimeFrame, for one, for the TimeFrame we typically group various raw labels together). In `labels` we have all labels for the TimePoint and in `scores` we have all classifier scores for the labels. 

--- a/app.py
+++ b/app.py
@@ -68,7 +68,7 @@ class SwtDetection(ClamsApp):
                 prediction.annotation = timepoint_annotation
                 scores = [prediction.score_for_label(lbl) for lbl in prediction.labels]
                 label = self._label_with_highest_score(prediction.labels, scores)
-                timepoint_annotation.add_property('timePont', prediction.timepoint)
+                timepoint_annotation.add_property('timePoint', prediction.timepoint)
                 timepoint_annotation.add_property('label', label)
                 timepoint_annotation.add_property('labels', prediction.labels)
                 timepoint_annotation.add_property('scores', scores)

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@
 CLAMS app to detect scenes with text.
 
 The kinds of scenes that are recognized depend on the model used but typically
-include slates, chryons and credits.
+include slates, chyrons and credits.
 
 """
 
@@ -15,6 +15,7 @@ from typing import Union
 import yaml
 from clams import ClamsApp, Restifier
 from mmif import Mmif, View, AnnotationTypes, DocumentTypes
+from mmif.utils import video_document_helper as vdh
 
 from modeling import classify, stitch
 
@@ -48,8 +49,9 @@ class SwtDetection(ClamsApp):
             new_view.metadata.add_warnings(warning)
             return mmif
         vd = vds[0]
-
-        predictions = self.classifier.process_video(vd.location_path(nonexist_ok=False))
+        self.logger.info(f"Processing video {vd.id} at {vd.location_path()}")
+        vcap = vdh.capture(vd)
+        predictions = self.classifier.process_video(vcap)
         timeframes = self.stitcher.create_timeframes(predictions)
 
         new_view.new_contain(
@@ -98,7 +100,8 @@ class SwtDetection(ClamsApp):
             elif parameter == "minFrameCount":
                 self.stitcher.min_frame_count = value
 
-    def _label_with_highest_score(self, labels: list, scores: list) -> str:
+    @staticmethod
+    def _label_with_highest_score(labels: list, scores: list) -> str:
         """Return the label associated with the highest scores. The score for 
         labels[i] is scores[i]."""
         # TODO: now the NEG scores are included, perhaps not do that

--- a/app.py
+++ b/app.py
@@ -38,7 +38,6 @@ class SwtDetection(ClamsApp):
 
     def _annotate(self, mmif: Union[str, dict, Mmif], **parameters) -> Mmif:
 
-        parameters = self.get_configuration(**parameters)
         new_view: View = mmif.new_view()
         self.sign_view(new_view, parameters)
         self._export_parameters(parameters)

--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ from clams import ClamsApp, Restifier
 from mmif import Mmif, View, AnnotationTypes, DocumentTypes
 from mmif.utils import video_document_helper as vdh
 
-from modeling import classify, stitch
+from modeling import classify, stitch, negative_label
 
 logging.basicConfig(filename='swt.log', level=logging.DEBUG)
 
@@ -54,16 +54,22 @@ class SwtDetection(ClamsApp):
         predictions = self.classifier.process_video(vcap)
         timeframes = self.stitcher.create_timeframes(predictions)
 
+        labelset = self.classifier.postbin_labels
+        bins = self.classifier.model_config['bins']
+
         new_view.new_contain(
-            AnnotationTypes.TimeFrame, document=vd.id, timeUnit='milliseconds')
+            AnnotationTypes.TimeFrame,
+            document=vd.id, timeUnit='milliseconds', labelset=labelset)
         new_view.new_contain(
-            AnnotationTypes.TimePoint, document=vd.id, timeUnit='milliseconds')
+            AnnotationTypes.TimePoint,
+            document=vd.id, timeUnit='milliseconds', labelset=labelset)
 
         for tf in timeframes:
             timeframe_annotation = new_view.new_annotation(AnnotationTypes.TimeFrame)
-            timeframe_annotation.add_property("frameType", tf.label),
-            timeframe_annotation.add_property("score", tf.score)
-            timeframe_annotation.add_property("scores", tf.scores)
+            timeframe_annotation.add_property("label", tf.label),
+            timeframe_annotation.add_property('classification', {tf.label: tf.score})
+            #timeframe_annotation.add_property("score", tf.score)
+            #timeframe_annotation.add_property("scores", tf.scores)
             timepoint_annotations = []
             for prediction in tf.targets:
                 timepoint_annotation = new_view.new_annotation(AnnotationTypes.TimePoint)
@@ -71,6 +77,7 @@ class SwtDetection(ClamsApp):
                 scores = [prediction.score_for_label(lbl) for lbl in prediction.labels]
                 label = self._label_with_highest_score(prediction.labels, scores)
                 classification = {l:s for l, s in zip(prediction.labels, scores)}
+                classification = self._transform(classification, bins)
                 timepoint_annotation.add_property('timePoint', prediction.timepoint)
                 timepoint_annotation.add_property('label', label)
                 timepoint_annotation.add_property('classification', classification)
@@ -108,6 +115,17 @@ class SwtDetection(ClamsApp):
         sorted_scores = list(sorted(zip(scores, labels), reverse=True))
         return sorted_scores[0][1]
 
+    @staticmethod
+    def _transform(classification: dict, bins: dict):
+        """Take the raw classification and turn it into a classification of user
+        labels. Also includes modeling.negative_label."""
+        # TODO: this may not work when there is pre-binning
+        transformed = {}
+        for postlabel in bins['post'].keys():
+            score = sum([classification[lbl] for lbl in bins['post'][postlabel]])
+            transformed[postlabel] = score
+        transformed[negative_label] = 1 - sum(transformed.values())
+        return transformed
 
 
 if __name__ == "__main__":

--- a/metadata.py
+++ b/metadata.py
@@ -52,7 +52,7 @@ def appmetadata() -> AppMetadata:
         name='minFrameScore', type='number', default=0.01,
         description='Minimum score for a still frame to be included in a TimeFrame')
     metadata.add_parameter(
-        name='minTimeframeScore', type='number', default=0.25,
+        name='minTimeframeScore', type='number', default=0.50,
         description='Minimum score for a TimeFrame')
     metadata.add_parameter(
         name='minFrameCount', type='integer', default=2,

--- a/metadata.py
+++ b/metadata.py
@@ -28,10 +28,11 @@ def appmetadata() -> AppMetadata:
     )
 
     metadata.add_input(DocumentTypes.VideoDocument, required=True)
-    metadata.add_output(AnnotationTypes.TimeFrame, frameType='bars')
-    metadata.add_output(AnnotationTypes.TimeFrame, frameType='slate')
-    metadata.add_output(AnnotationTypes.TimeFrame, frameType='chyron')
-    metadata.add_output(AnnotationTypes.TimeFrame, frameType='credits')
+    metadata.add_output(AnnotationTypes.TimeFrame, timeUnit='milliseconds', frameType='bars')
+    metadata.add_output(AnnotationTypes.TimeFrame, timeUnit='milliseconds', frameType='slate')
+    metadata.add_output(AnnotationTypes.TimeFrame, timeUnit='milliseconds', frameType='chyron')
+    metadata.add_output(AnnotationTypes.TimeFrame, timeUnit='milliseconds', frameType='credits')
+    metadata.add_output(AnnotationTypes.TimePoint, timeUnit='milliseconds')
 
     # TODO: defaults are the same as in modeling/config/classifier.yml, which is possibly
     # not a great idea, should perhaps read defaults from the configuration file. There is

--- a/modeling/classify.py
+++ b/modeling/classify.py
@@ -239,6 +239,7 @@ def open_mp4_file(mp4_file, verbose=False):
         raise IOError(f'Could not open {mp4_file}')
     return mp4_vidcap
 
+
 if __name__ == '__main__':
 
     args = parse_args()
@@ -259,7 +260,7 @@ if __name__ == '__main__':
     if args.use_predictions:
         predictions = load_predictions(predictions_file, classifier.prebin_labels)
     else:
-        predictions = classifier.process_video(args.input)
+        predictions = classifier.process_video(mp4_vidcap)
         if args.save_predictions:
             save_predictions(predictions, predictions_file)
 

--- a/modeling/classify.py
+++ b/modeling/classify.py
@@ -78,18 +78,13 @@ class Classifier:
                 + f'pos_enc_name="{self.model_config["pos_enc_name"]}" '
                 + f'sample_rate={self.get_sample_rate()}>')
 
-    def process_video(self, mp4_file: str) -> list:
+    def process_video(self, vidcap: cv2.VideoCapture) -> list:
         """Loops over the frames in a video and for each frame extracts the features
         and applies the classifier. Returns a list of predictions, where each prediction
         is an instance of numpy.ndarray."""
         if self.debug:
-            print(f'Processing {mp4_file}...')
             print(f'Labels: {self.prebin_labels}')
-        logging.info(f'processing {mp4_file}...')
         predictions = []
-        vidcap = cv2.VideoCapture(mp4_file)
-        if not vidcap.isOpened():
-            raise IOError(f'Could not open {mp4_file}')
         fps = round(vidcap.get(cv2.CAP_PROP_FPS), 2)
         fc = vidcap.get(cv2.CAP_PROP_FRAME_COUNT)
         dur = round(fc / fps, 3) * 1000
@@ -236,6 +231,14 @@ def add_parameters(args: dict, classifier: Classifier, stitcher: stitch.Stitcher
         classifier.stop_at = int(args.stop)
 
 
+def open_mp4_file(mp4_file, verbose=False):
+    if verbose:
+        print(f'Processing {args.input}...')
+    mp4_vidcap = cv2.VideoCapture(mp4_file)
+    if not mp4_vidcap.isOpened():
+        raise IOError(f'Could not open {mp4_file}')
+    return mp4_vidcap
+
 if __name__ == '__main__':
 
     args = parse_args()
@@ -247,6 +250,9 @@ if __name__ == '__main__':
     if args.debug:
         print(classifier)
         print(stitcher)
+    mp4_vidcap = open_mp4_file(args.input, args.debug)
+    if not mp4_vidcap.isOpened():
+        raise IOError(f'Could not open {args.input}')
 
     input_basename, extension = os.path.splitext(args.input)
     predictions_file = f'{input_basename}.json'

--- a/modeling/evaluate.py
+++ b/modeling/evaluate.py
@@ -27,8 +27,6 @@ the first.
 
 """
 
-# TODO: this should probably live in the modeling package
-
 
 import os
 import csv
@@ -37,13 +35,13 @@ from mmif import Mmif
 
 
 # MMIF files
-mmif_files = ('ex-aapb-50.json', 'ex-aapb-69.json', 'ex-aapb-75.json')
+mmif_files = ('../ex-aapb-50.json', '../ex-aapb-69.json', '../ex-aapb-75.json')
 
 # Annotation files
 gold_files = (
-    'modeling/annotations-gbh/cpb-aacip-507-028pc2tp2z.csv',
-    'modeling/annotations-gbh/cpb-aacip-690722078b2.csv',
-    'modeling/annotations-gbh/cpb-aacip-75-72b8h82x.csv')
+    'annotations-gbh/cpb-aacip-507-028pc2tp2z.csv',
+    'annotations-gbh/cpb-aacip-690722078b2.csv',
+    'annotations-gbh/cpb-aacip-75-72b8h82x.csv')
 
 # Mappings from raw labels to binned labels
 bin_mappings = {

--- a/modeling/stitch.py
+++ b/modeling/stitch.py
@@ -24,7 +24,7 @@ class Stitcher:
         self.min_timeframe_score = config.get("minTimeframeScore")
         self.min_frame_count = config.get("minFrameCount")
         self.static_frames = self.config.get("staticFrames")
-        self.prebin_labels = train.pre_bin_label_names(self.model_config)
+        self.prebin_labels = train.pre_bin_label_names(self.model_config, train.RAW_LABELS)
         self.postbin_labels = train.post_bin_label_names(self.model_config)
         self.use_postbinning = "post" in self.model_config["bins"]
         self.debug = False
@@ -35,6 +35,9 @@ class Stitcher:
                 + f'min_frame_count={self.min_frame_count}>')
 
     def create_timeframes(self, predictions: list) -> list:
+        if self.debug:
+            print('pre-bin labels', self.prebin_labels)
+            print('post-bin labels', self.postbin_labels)
         timeframes = self.collect_timeframes(predictions)
         if self.debug:
             print_timeframes('Collected frames', timeframes)
@@ -59,6 +62,8 @@ class Stitcher:
         timeframes = []
         open_frames = { label: TimeFrame(label, self) for label in labels}
         for prediction in predictions:
+            if self.debug:
+                print(prediction)
             for label in [label for label in labels if label != negative_label]:
                 score = self._score_for_label(label, prediction)
                 if score < self.min_frame_score:
@@ -109,6 +114,7 @@ class Stitcher:
         if not self.use_postbinning:
             return prediction.score_for_label(label)
         else:
+            postbins = self.model_config['bins']['post']
             return prediction.score_for_labels(postbins[label])
 
 

--- a/modeling/stitch.py
+++ b/modeling/stitch.py
@@ -47,6 +47,7 @@ class Stitcher:
         timeframes = self.remove_overlapping_timeframes(timeframes)
         for tf in timeframes:
             tf.set_representatives()
+        timeframes = list(sorted(timeframes, key=(lambda tf: tf.start)))
         if self.debug:
             print_timeframes('Final frames', timeframes)
         return timeframes

--- a/modeling/train.py
+++ b/modeling/train.py
@@ -37,6 +37,13 @@ FRAME_TYPES = ["B", "S", "S:H", "S:C", "S:D", "S:B", "S:G", "W", "L", "O",
                "M", "I", "N", "E", "P", "Y", "K", "G", "T", "F", "C", "R"]
 RESULTS_DIR = Path(__file__).parent / f"results-{platform.node().split('.')[0]}"
 
+# The layers in the underlaying classification, before pre-binning.
+# Should perhaps live in a config file
+RAW_LABELS = [
+    'B', 'S', 'S:H', 'S:C', 'S:D', 'S:B', 'S:G', 
+    'W', 'L', 'O', 'M', 'I', 'N', 'E', 'P', 'Y', 'K', 'G', 'T', 'F', 'C', 'R']
+RAW_LABEL_COUNT = len(RAW_LABELS) + 1
+
 
 class SWTDataset(Dataset):
     def __init__(self, backbone_model_name, labels, vectors):
@@ -265,8 +272,13 @@ def export_kfold_results(trial_specs, p_scores, r_scores, f_scores, p_results, *
         out.write(f'\trecall = {sum(r_scores) / len(r_scores)}\n')
 
 
-def pre_bin_label_names(config):
-    return list(config["bins"]["pre"].keys()) + [modeling.negative_label]
+def pre_bin_label_names(config, raw_labels=None):
+    if 'pre' in config["bins"]:
+        return list(config["bins"]["pre"].keys()) + [modeling.negative_label]
+    elif raw_labels is not None:
+        return raw_labels
+    else:
+        return []
 
 def post_bin_label_names(config):
     post_labels = list(config["bins"].get("post", {}).keys())

--- a/modeling/visualize.py
+++ b/modeling/visualize.py
@@ -21,8 +21,6 @@ Some things to change here:
 
 """
 
-# TODO: this should probably live in the modeling package
-
 
 import os
 import sys

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-clams-python==1.1.0
+clams-python==1.1.2
 torch==2.*
 torchvision
 torchmetrics


### PR DESCRIPTION
### Overview

This version uses the new classification regime with a dictionary of labels and scores, where labels are defined on the metadata. The same labels are used for the TimeFrames and TimePoints (previously, the TimePoints had pre-bin labels). TimePoint evaluation was added and the TimePoint visualizer was updated.

### Additions

* Added the classification property and the labels metadata property
* Added time point evaluation
* Video document metadata are added as an annotation

### Changes

* Updated clams-python dependency to 1.1.2
* Using post-label categories for both the TimeFrames and TimePoints
* Fixed timePont typo (#68)
* Changed threshold of timeframe score to 0.5
* Updated time point visualization
* Various small fixes, some refactoring
