### PR TITLE
Releasing 4.0

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,16 +68,14 @@ class SwtDetection(ClamsApp):
             timeframe_annotation = new_view.new_annotation(AnnotationTypes.TimeFrame)
             timeframe_annotation.add_property("label", tf.label),
             timeframe_annotation.add_property('classification', {tf.label: tf.score})
-            #timeframe_annotation.add_property("score", tf.score)
-            #timeframe_annotation.add_property("scores", tf.scores)
             timepoint_annotations = []
             for prediction in tf.targets:
                 timepoint_annotation = new_view.new_annotation(AnnotationTypes.TimePoint)
                 prediction.annotation = timepoint_annotation
                 scores = [prediction.score_for_label(lbl) for lbl in prediction.labels]
-                label = self._label_with_highest_score(prediction.labels, scores)
                 classification = {l:s for l, s in zip(prediction.labels, scores)}
                 classification = self._transform(classification, bins)
+                label = max(classification, key=classification.get)
                 timepoint_annotation.add_property('timePoint', prediction.timepoint)
                 timepoint_annotation.add_property('label', label)
                 timepoint_annotation.add_property('classification', classification)
@@ -106,14 +104,6 @@ class SwtDetection(ClamsApp):
                 self.stitcher.min_timeframe_score = value
             elif parameter == "minFrameCount":
                 self.stitcher.min_frame_count = value
-
-    @staticmethod
-    def _label_with_highest_score(labels: list, scores: list) -> str:
-        """Return the label associated with the highest scores. The score for 
-        labels[i] is scores[i]."""
-        # TODO: now the NEG scores are included, perhaps not do that
-        sorted_scores = list(sorted(zip(scores, labels), reverse=True))
-        return sorted_scores[0][1]
 
     @staticmethod
     def _transform(classification: dict, bins: dict):

--- a/metadata.py
+++ b/metadata.py
@@ -27,12 +27,10 @@ def appmetadata() -> AppMetadata:
         url="https://github.com/clamsproject/app-swt-detection"
     )
 
+    labels = ['bars', 'slate', 'chyron', 'credits', 'NEG']
     metadata.add_input(DocumentTypes.VideoDocument, required=True)
-    metadata.add_output(AnnotationTypes.TimeFrame, timeUnit='milliseconds', frameType='bars')
-    metadata.add_output(AnnotationTypes.TimeFrame, timeUnit='milliseconds', frameType='slate')
-    metadata.add_output(AnnotationTypes.TimeFrame, timeUnit='milliseconds', frameType='chyron')
-    metadata.add_output(AnnotationTypes.TimeFrame, timeUnit='milliseconds', frameType='credits')
-    metadata.add_output(AnnotationTypes.TimePoint, timeUnit='milliseconds')
+    metadata.add_output(AnnotationTypes.TimeFrame, timeUnit='milliseconds', labelset=labels)
+    metadata.add_output(AnnotationTypes.TimePoint, timeUnit='milliseconds', labelset=labels)
 
     # TODO: defaults are the same as in modeling/config/classifier.yml, which is possibly
     # not a great idea, should perhaps read defaults from the configuration file. There is


### PR DESCRIPTION
### Overview

This version uses the new classification regime with a dictionary of labels and scores, where labels are defined on the metadata. The same labels are used for the TimeFrames and TimePoints (previously, the TimePoints had pre-bin labels). TimePoint evaluation was added and the TimePoint visualizer was updated.

### Additions

* Added the classification property and the labels metadata property
* Added time point evaluation
* Video document metadata are added as an annotation

### Changes

* Updated clams-python dependency to 1.1.2
* Using post-label categories for both the TimeFrames and TimePoints
* Fixed timePont typo (#68)
* Changed threshold of timeframe score to 0.5
* Updated time point visualization
* Various small fixes, some refactoring
